### PR TITLE
Configure Astro for GitHub Pages

### DIFF
--- a/astro/astro.config.mjs
+++ b/astro/astro.config.mjs
@@ -6,6 +6,8 @@ import mdx from '@astrojs/mdx';
 
 // https://astro.build/config
 export default defineConfig({
+  site: 'https://kodexArg.github.io/syv',
+  base: '/syv/',
   integrations: [mdx()],
   
   // Configuración simplificada de Markdown


### PR DESCRIPTION
## Summary
- set `site` and `base` in `astro.config.mjs` so assets resolve correctly when deployed to `https://kodexArg.github.io/syv`

## Testing
- `npm run build` *(fails: `astro` not found because dependencies aren't installed)*

------
https://chatgpt.com/codex/tasks/task_e_686c83a30ae08330850813c082761e08