### PR TITLE
Configure Astro for GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,47 @@
+name: Deploy site to GitHub Pages
+
+on:
+  push:
+    branches: [work, main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: astro/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+        working-directory: astro
+      - name: Build
+        run: npm run build
+        working-directory: astro
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: astro/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -40,3 +40,11 @@ npm run preview      # Previsualiza la build localmente
 - **Sitio web**: El código de Astro está en la carpeta `astro/`
 - **Guías**: Las guías para colaboradores están en `0_proyecto/guias-para-colaboradores/`
 
+
+### Despliegue en GitHub Pages
+
+El repositorio incluye un _workflow_ de GitHub Actions en `.github/workflows/deploy.yml` que construye el sitio desde `astro/` y lo publica automaticamente en GitHub Pages.
+
+1. Asegúrate de que la opción **Pages** del repositorio esté configurada para utilizar *GitHub Actions*.
+2. Al hacer _push_ a las ramas `work` o `main` se generará la carpeta `dist/` y se desplegará en `https://kodexArg.github.io/syv/`.
+

--- a/astro/astro.config.mjs
+++ b/astro/astro.config.mjs
@@ -6,6 +6,8 @@ import mdx from '@astrojs/mdx';
 
 // https://astro.build/config
 export default defineConfig({
+  site: 'https://kodexArg.github.io/syv',
+  base: '/syv/',
   integrations: [mdx()],
   
   // Configuración simplificada de Markdown


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and deploy the site to Pages
- document GitHub Pages deployment steps in the README

## Testing
- `npm run build` *(fails: `astro` not found because dependencies aren't installed)*

------
https://chatgpt.com/codex/tasks/task_e_686c83a30ae08330850813c082761e08